### PR TITLE
exit with non-zero status if spelling errors are found

### DIFF
--- a/testdata/complete.txt
+++ b/testdata/complete.txt
@@ -1,5 +1,5 @@
 # Show vetting a complete program with multiple distinct errors.
-gospel -check-strings -show=false
+! gospel -check-strings -show=false
 ! stderr .
 
 stdout 'main.go:13:10: "misktaes" is misspelled in string'
@@ -10,7 +10,7 @@ stdout 'main.go:1:1: "seperate" is misspelled in comment'
 stdout 'main.go:10:1: "_nothign_" is misspelled in comment'
 
 # Don't ignore errors that match identifiers, but make a dictionary.
-gospel -check-strings -ignore-idents=false -show=false -misspellings=.words
+! gospel -check-strings -ignore-idents=false -show=false -misspellings=.words
 ! stderr .
 
 stdout 'main.go:13:10: "misktaes" is misspelled in string'

--- a/testdata/local_dictionary.txt
+++ b/testdata/local_dictionary.txt
@@ -1,5 +1,5 @@
 # Generate a local dictionary of misspelled words.
-gospel -show=false -misspellings=.words -update-dict=false
+! gospel -show=false -misspellings=.words -update-dict=false
 stdout 'main.go:3:1: "Speeling" is misspelled in comment'
 ! stdout '	\x1b\[31;1;3mSpeeling\x1b\[0m\ error.'
 ! stderr .

--- a/testdata/misspelling_comment.txt
+++ b/testdata/misspelling_comment.txt
@@ -1,5 +1,5 @@
 # Show misspelling in a comment and correct colourisation.
-gospel
+! gospel
 stdout 'main.go:3:1: "Speeling" is misspelled in comment'
 stdout '	\x1b\[31;1;3mSpeeling\x1b\[0m\ error.'
 ! stderr .

--- a/testdata/misspelling_string.txt
+++ b/testdata/misspelling_string.txt
@@ -7,7 +7,7 @@ gospel -check-strings=false
 ! stdout .
 ! stderr .
 
-gospel -check-strings
+! gospel -check-strings
 stdout 'main.go:4:10: "Speeling" is misspelled in string'
 stdout '	"\x1b\[31;1;3mSpeeling\x1b\[0m error\."'
 ! stderr .

--- a/testdata/single.txt
+++ b/testdata/single.txt
@@ -1,5 +1,5 @@
 # Show single-letter misspelling is ignored when requested.
-gospel -ignore-single=false
+! gospel -ignore-single=false
 stdout 'main.go:3:1: "ϵ" is misspelled in comment'
 stdout '	\x1b\[31;1;3mϵ\x1b\[0m'
 ! stderr .

--- a/testdata/type_word.txt
+++ b/testdata/type_word.txt
@@ -3,7 +3,7 @@ gospel -ignore-idents=true
 ! stdout .
 ! stderr .
 
-gospel -ignore-idents=false
+! gospel -ignore-idents=false
 stdout 'main.go:3:1: "_Speeling_" is misspelled in comment'
 stdout '	\x1b\[31;1;3m_Speeling_\x1b\[0m\ error.'
 

--- a/testdata/update_local_dictionary.txt
+++ b/testdata/update_local_dictionary.txt
@@ -1,5 +1,5 @@
 # Update aa existing local dictionary of misspelled words.
-gospel -show=false -misspellings=.words -update-dict=true
+! gospel -show=false -misspellings=.words -update-dict=true
 stdout 'main.go:3:1: "errah" is misspelled in comment'
 ! stdout 'Speeling'
 ! stderr .

--- a/testdata/uppercase.txt
+++ b/testdata/uppercase.txt
@@ -1,5 +1,5 @@
 # Show all-uppercase words (including numerals and underscores) can be ignored.
-gospel -ignore-upper=false
+! gospel -ignore-upper=false
 stdout 'main.go:3:1: "FL1M_FLAM" is misspelled in comment'
 stdout '	\x1b\[31;1;3mFL1M_FLAM\x1b\[0m'
 ! stderr .


### PR DESCRIPTION
This makes a future use in CI easier.

/cc @philpennock this is a heads up.