### PR TITLE
consider underscore-separated parts of unrecognised word before rejection

### DIFF
--- a/testdata/underscore_fragments.txt
+++ b/testdata/underscore_fragments.txt
@@ -1,0 +1,18 @@
+# Show underscore-separated words are allowed when all parts are accepted as correct.
+! gospel -ignore-single=false
+stdout 'main.go:3:1: "_ϵ_together_unknown_apart_correct_when_singles_allowed_" is misspelled in comment'
+stdout '	\x1b\[31;1;3m_ϵ_together_unknown_apart_correct_when_singles_allowed_\x1b\[0m'
+! stderr .
+
+gospel -ignore-single=true
+! stdout .
+! stderr .
+
+-- go.mod --
+module dummy
+-- main.go --
+package main
+
+// _ϵ_together_unknown_apart_correct_when_singles_allowed_
+func main() {
+}


### PR DESCRIPTION
Reduces detected misspelled words int the Go project by 400 comment spellings (from 9853) and 90 string spellings (from 88346).