### PR TITLE
add initial support for camel case recognition

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -9,6 +9,7 @@ require (
 )
 
 require (
+	github.com/kortschak/camel v0.0.0-20220208065757-0665e01e7dba // indirect
 	github.com/pkg/diff v0.0.0-20210226163009-20ebb0f2a09e // indirect
 	gopkg.in/errgo.v2 v2.1.0 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -1,3 +1,5 @@
+github.com/kortschak/camel v0.0.0-20220208065757-0665e01e7dba h1:140WFLaM7yYmAjBaeulEJJ9JJ//2Mpz08e5DfGXsGKs=
+github.com/kortschak/camel v0.0.0-20220208065757-0665e01e7dba/go.mod h1:ROOXSC/EYpQz07U4MnCkMbXvKNC7O6iRolPUl/L2BZU=
 github.com/kortschak/ct v0.0.0-20140325011614-7d86dffe6951 h1:I12D1A/+qvQfb7cENS32wTtXNF9dh7S8H847WGjnJ1U=
 github.com/kortschak/ct v0.0.0-20140325011614-7d86dffe6951/go.mod h1:5l1kPezpRemBE+Nj0tHiYk9JXHpgYwg0sOC5pvEScm8=
 github.com/kortschak/hunspell v0.0.0-20220130032629-3553eecdf4e7 h1:N2v0GNR6GT0EYbO7FNbOgtw1J0fJS9K2GW4Pa6EJ3Lk=

--- a/main.go
+++ b/main.go
@@ -383,7 +383,7 @@ func (a *adder) Visit(n ast.Node) ast.Visitor {
 // words to prevent emph marking used in comments from preventing
 // spell check matching.
 func stripUnderscores(s string) string {
-	return strings.TrimLeft(strings.TrimRight(s, "_"), "_")
+	return strings.TrimFunc(s, func(r rune) bool { return r == '_' })
 }
 
 // allUpper returns whether all runes in s are uppercase. For the purposed

--- a/testdata/camel_case_fragments.txt
+++ b/testdata/camel_case_fragments.txt
@@ -1,0 +1,17 @@
+# Show underscore-separated words are allowed when all parts are accepted as correct.
+! gospel -camel=false
+stdout 'main.go:3:1: "ExampleWholeProgram" is misspelled in comment'
+! stderr .
+
+gospel
+! stdout .
+! stderr .
+
+-- go.mod --
+module dummy
+-- main.go --
+package main
+
+// ExampleWholeProgram
+func main() {
+}


### PR DESCRIPTION
The camel package allows finer-tuned recognition of words, but that depends on configuration.