### PR TITLE
don't attempt to find correct camel case splits when case-folded match exists

### DIFF
--- a/checker.go
+++ b/checker.go
@@ -179,7 +179,9 @@ func (c *checker) isCorrect(word string, isRetry bool) bool {
 	if c.spelling.IsCorrect(word) {
 		return true
 	}
-	if isRetry {
+	if isRetry || c.caseFoldMatch(word) {
+		// TODO(kortschak): Consider not adding case-fold
+		// matches to the misspelled map.
 		c.misspellings++
 		if c.misspelled != nil {
 			c.misspelled[word] = true
@@ -200,6 +202,18 @@ func (c *checker) isCorrect(word string, isRetry bool) bool {
 		}
 	}
 	return true
+}
+
+// caseFoldMatch returns whether there is a suggestion for the word that
+// is an exact match under case folding. This checks for the common error
+// of failing to adjust export visibility of labels in comments.
+func (c *checker) caseFoldMatch(word string) bool {
+	for _, suggest := range c.spelling.Suggest(word) {
+		if strings.EqualFold(suggest, word) {
+			return true
+		}
+	}
+	return false
 }
 
 // Visit walks the AST performing spell checking on any string literals.

--- a/testdata/wrong_case.txt
+++ b/testdata/wrong_case.txt
@@ -1,0 +1,21 @@
+# Check case matters in camel-cased words.
+! gospel -show=false -misspellings=words
+stdout 'main.go:5:1: "KillTimeout" is misspelled in comment'
+! stderr .
+
+# Check the complete list matches our expectation.
+cmp words expected_words
+
+-- go.mod --
+module dummy
+-- main.go --
+package interp
+
+import "time"
+
+// KillTimeout is a duration to wait before sending the Kill signal on Timeout.
+func DefaultExecHandler(killTimeout time.Duration) {
+}
+-- expected_words --
+1
+KillTimeout


### PR DESCRIPTION
Addresses the issue seen in https://github.com/mvdan/sh/pull/812#pullrequestreview-883593806.

/cc @mvdan