### PR TITLE
make string checks dependent on total string entropy

### DIFF
--- a/testdata/rune_literal.txt
+++ b/testdata/rune_literal.txt
@@ -1,4 +1,4 @@
-gospel -show=false -check-strings -max-word-len=16
+gospel -show=false -check-strings -max-word-len=20 -entropy-filter
 ! stdout .
 ! stderr .
 
@@ -86,10 +86,3 @@ var properties = [MaxLatin1 + 1]uint8{
 	0x89: pC,       // '\u0089'
 	0xAD: 0,        // '\u00ad'
 }
--- .words --
-5
-0e
-ux
-x0e
-x15
-xac

--- a/testdata/write_config.txt
+++ b/testdata/write_config.txt
@@ -20,3 +20,10 @@ camel = true
 max_word_len = 30
 min_naked_hex = 8
 suggest = 0
+
+[entropy_filter]
+  filter = false
+  min_len_filtered = 16
+  [entropy_filter.accept]
+    low = 14
+    high = 20


### PR DESCRIPTION
The long text range in the config should encompasses natural English while
rejecting things like base64 encoded data; 5 bits almost encodes 26 letters
plus 10 digits. The short text filtering does a reasonable job at filtering
unexpected text, but is not based in any real theory. It should be improved.