### PR TITLE
collate errors as lines where possible

### DIFF
--- a/report.go
+++ b/report.go
@@ -1,0 +1,174 @@
+// Copyright ©2022 Dan Kortschak. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package main
+
+import (
+	"fmt"
+	"go/token"
+	"sort"
+	"strings"
+)
+
+// misspelling is an identified misspelled word and its position.
+type misspelling struct {
+	text  string
+	where string
+	pos   token.Position
+	end   token.Position
+	words []misspelled
+}
+
+// misspelled is a misspelled word and its span.
+type misspelled struct {
+	word string
+	span span
+}
+
+// adjacent returns whether the receiver is on an adjacent line to
+// prev.
+func (m misspelling) adjacent(prev misspelling) bool {
+	return m.pos.Filename == prev.pos.Filename &&
+		m.pos.Line-prev.end.Line <= 1
+}
+
+// report writes a report to stdout.
+func (c *checker) report() {
+	sort.Slice(c.misspellings, func(i, j int) bool {
+		mi := c.misspellings[i]
+		mj := c.misspellings[j]
+		switch {
+		case mi.pos.Filename < mj.pos.Filename:
+			return true
+		case mi.pos.Filename > mj.pos.Filename:
+			return false
+		default:
+			return mi.pos.Offset < mj.pos.Offset
+		}
+	})
+
+	var (
+		chunks  [][]misspelling
+		current []misspelling
+	)
+	for i, m := range c.misspellings {
+		if i != 0 && !m.adjacent(c.misspellings[i-1]) {
+			chunks = append(chunks, current)
+			current = nil
+		}
+		current = append(current, m)
+	}
+	if current != nil {
+		chunks = append(chunks, current)
+	}
+
+	for _, chunk := range chunks {
+		for _, l := range chunk {
+			for _, w := range l.words {
+				p := l.pos
+				fmt.Printf("%v:%d:%d: %q is misspelled in %s", rel(p.Filename), p.Line, p.Column+w.span.pos, w.word, l.where)
+
+				if c.MakeSuggestions == always || (c.MakeSuggestions == once && c.suggested[w.word] == nil) {
+					suggestions, ok := c.suggested[w.word]
+					if !ok {
+						suggestions = c.dictionary.Suggest(w.word)
+						if c.MakeSuggestions == always {
+							// Cache suggestions.
+							c.suggested[w.word] = suggestions
+						} else {
+							// Mark as suggested.
+							c.suggested[w.word] = empty
+						}
+					}
+					if len(suggestions) != 0 {
+						fmt.Print(" (suggest: ")
+						for i, s := range suggestions {
+							if i != 0 {
+								fmt.Print(", ")
+							}
+							fmt.Printf("%s", c.suggest(s))
+						}
+						fmt.Print(")")
+					}
+				}
+				fmt.Println()
+			}
+		}
+
+		if c.Show {
+			for i, l := range chunk {
+				if len(l.words) == 0 {
+					if i == 0 || l.text != chunk[i-1].text {
+						fmt.Print(adjustIndents(l.text))
+					}
+					continue
+				}
+				var (
+					args    []interface{}
+					lastPos int
+				)
+				for _, w := range l.words {
+					if w.span.pos != lastPos {
+						args = append(args, l.text[lastPos:w.span.pos])
+					}
+					args = append(args, c.warn(l.text[w.span.pos:w.span.pos+len(w.word)]), l.text[w.span.pos+len(w.word):w.span.end])
+					lastPos = w.span.end
+				}
+				if lastPos != len(l.text) {
+					args = append(args, l.text[lastPos:])
+				}
+
+				if args != nil {
+					fmt.Print(adjustIndents(join(args)))
+				}
+			}
+		}
+	}
+}
+
+// join returns the string join of the given args.
+func join(args []interface{}) string {
+	var buf strings.Builder
+	for _, a := range args {
+		fmt.Fprint(&buf, a)
+	}
+	return buf.String()
+}
+
+// adjustIndents adjusts indents to that all blocks are indented a single
+// tab.
+func adjustIndents(s string) string {
+	indent := indentLevel(s)
+	lines := strings.Split(s, "\n")
+	var buf strings.Builder
+	for i, l := range lines {
+		if l == "" {
+			continue
+		}
+		if i != 0 {
+			l = l[indent:]
+		}
+		fmt.Fprintf(&buf, "\t%s\n", l)
+	}
+	return buf.String()
+}
+
+// indentLevel returns the indent level of a block comment. It returns
+// zero if chunk is not a block comment.
+func indentLevel(chunk string) int {
+	if !strings.HasPrefix(chunk, "/*") {
+		return 0
+	}
+	lastLine := strings.LastIndex(chunk, "\n")
+	if lastLine < 0 {
+		return 0
+	}
+	// Assume correctly formatted code with tab indentation.
+	for i, r := range chunk[lastLine+1:] {
+		if r != '\t' {
+			return i
+		}
+	}
+	return -1
+}

--- a/testdata/camel_case_fragments.txt
+++ b/testdata/camel_case_fragments.txt
@@ -1,6 +1,6 @@
 # Show underscore-separated words are allowed when all parts are accepted as correct.
 ! gospel -camel=false
-stdout 'main.go:3:1: "ExampleWholeProgram" is misspelled in comment'
+stdout 'main.go:3:4: "ExampleWholeProgram" is misspelled in comment'
 ! stderr .
 
 gospel

--- a/testdata/camel_case_fragments.txt
+++ b/testdata/camel_case_fragments.txt
@@ -1,7 +1,8 @@
 # Show underscore-separated words are allowed when all parts are accepted as correct.
+
 ! gospel -camel=false
-stdout 'main.go:3:4: "ExampleWholeProgram" is misspelled in comment'
 ! stderr .
+cmp stdout expected_output
 
 gospel
 ! stdout .
@@ -15,3 +16,6 @@ package main
 // ExampleWholeProgram
 func main() {
 }
+-- expected_output --
+main.go:3:4: "ExampleWholeProgram" is misspelled in comment
+	// [31;1;3mExampleWholeProgram[0m

--- a/testdata/complete.txt
+++ b/testdata/complete.txt
@@ -2,27 +2,27 @@
 ! gospel -check-strings -show=false
 ! stderr .
 
-stdout 'main.go:13:10: "misktaes" is misspelled in string'
-stdout 'main.go:13:10: "litreals" is misspelled in string'
-stdout 'main.go:14:10: "fo" is misspelled in string'
-stdout 'main.go:1:1: "programme" is misspelled in comment'
-stdout 'main.go:1:1: "seperate" is misspelled in comment'
-stdout 'main.go:10:1: "_nothign_" is misspelled in comment'
+stdout 'main.go:1:23: "programme" is misspelled in comment'
+stdout 'main.go:1:59: "seperate" is misspelled in comment'
+stdout 'main.go:10:21: "_nothign_" is misspelled in comment'
+stdout 'main.go:13:21: "misktaes" is misspelled in string'
+stdout 'main.go:13:56: "litreals" is misspelled in string'
+stdout 'main.go:14:20: "fo" is misspelled in string'
 
 # Don't ignore errors that match identifiers, but make a dictionary.
 ! gospel -check-strings -ignore-idents=false -show=false -misspellings=.words
 ! stderr .
 
-stdout 'main.go:13:10: "misktaes" is misspelled in string'
-stdout 'main.go:13:10: "litreals" is misspelled in string'
-stdout 'main.go:14:10: "fo" is misspelled in string'
-stdout 'main.go:14:10: "_errirs_" is misspelled in string'
-stdout 'main.go:14:10: "thes" is misspelled in string'
-stdout 'main.go:14:10: "thet" is misspelled in string'
-stdout 'main.go:14:10: "fnagle" is misspelled in string'
-stdout 'main.go:1:1: "programme" is misspelled in comment'
-stdout 'main.go:1:1: "seperate" is misspelled in comment'
-stdout 'main.go:10:1: "_nothign_" is misspelled in comment'
+stdout 'main.go:1:23: "programme" is misspelled in comment'
+stdout 'main.go:1:59: "seperate" is misspelled in comment'
+stdout 'main.go:10:21: "_nothign_" is misspelled in comment'
+stdout 'main.go:13:21: "misktaes" is misspelled in string'
+stdout 'main.go:13:56: "litreals" is misspelled in string'
+stdout 'main.go:14:20: "fo" is misspelled in string'
+stdout 'main.go:14:27: "_errirs_" is misspelled in string'
+stdout 'main.go:14:81: "thes" is misspelled in string'
+stdout 'main.go:14:90: "thet" is misspelled in string'
+stdout 'main.go:14:118: "fnagle" is misspelled in string'
 
 # Check it matches our expectation.
 cmp .words expected_words

--- a/testdata/complete.txt
+++ b/testdata/complete.txt
@@ -1,28 +1,13 @@
 # Show vetting a complete program with multiple distinct errors.
+
 ! gospel -check-strings -show=false
 ! stderr .
-
-stdout 'main.go:1:23: "programme" is misspelled in comment'
-stdout 'main.go:1:59: "seperate" is misspelled in comment'
-stdout 'main.go:10:21: "_nothign_" is misspelled in comment'
-stdout 'main.go:13:21: "misktaes" is misspelled in string'
-stdout 'main.go:13:56: "litreals" is misspelled in string'
-stdout 'main.go:14:20: "fo" is misspelled in string'
+cmp stdout expected_output_ignore_idents
 
 # Don't ignore errors that match identifiers, but make a dictionary.
 ! gospel -check-strings -ignore-idents=false -show=false -misspellings=.words
 ! stderr .
-
-stdout 'main.go:1:23: "programme" is misspelled in comment'
-stdout 'main.go:1:59: "seperate" is misspelled in comment'
-stdout 'main.go:10:21: "_nothign_" is misspelled in comment'
-stdout 'main.go:13:21: "misktaes" is misspelled in string'
-stdout 'main.go:13:56: "litreals" is misspelled in string'
-stdout 'main.go:14:20: "fo" is misspelled in string'
-stdout 'main.go:14:27: "_errirs_" is misspelled in string'
-stdout 'main.go:14:81: "thes" is misspelled in string'
-stdout 'main.go:14:90: "thet" is misspelled in string'
-stdout 'main.go:14:118: "fnagle" is misspelled in string'
+cmp stdout expected_output_noignore_idents
 
 # Check it matches our expectation.
 cmp .words expected_words
@@ -67,3 +52,21 @@ programme
 seperate
 thes
 thet
+-- expected_output_ignore_idents --
+main.go:1:23: "programme" is misspelled in comment
+main.go:1:59: "seperate" is misspelled in comment
+main.go:10:21: "_nothign_" is misspelled in comment
+main.go:13:21: "misktaes" is misspelled in string
+main.go:13:56: "litreals" is misspelled in string
+main.go:14:20: "fo" is misspelled in string
+-- expected_output_noignore_idents --
+main.go:1:23: "programme" is misspelled in comment
+main.go:1:59: "seperate" is misspelled in comment
+main.go:10:21: "_nothign_" is misspelled in comment
+main.go:13:21: "misktaes" is misspelled in string
+main.go:13:56: "litreals" is misspelled in string
+main.go:14:20: "fo" is misspelled in string
+main.go:14:27: "_errirs_" is misspelled in string
+main.go:14:81: "thes" is misspelled in string
+main.go:14:90: "thet" is misspelled in string
+main.go:14:118: "fnagle" is misspelled in string

--- a/testdata/config.txt
+++ b/testdata/config.txt
@@ -1,13 +1,12 @@
 # Show config can be used and turned off.
+
 ! gospel -show=false
-stdout 'main.go:3:26: "Mistooken" is misspelled in string'
-stdout 'main.go:3:36: "tæxt" is misspelled in string'
 ! stderr .
+cmp stdout expected_output_config
 
 ! gospel -show=false -config=true
-stdout 'main.go:3:26: "Mistooken" is misspelled in string'
-stdout 'main.go:3:36: "tæxt" is misspelled in string'
 ! stderr .
+cmp stdout expected_output_config
 
 gospel -show=false -config=false
 ! stdout .
@@ -24,3 +23,6 @@ func main() {
 }
 -- .gospel.conf --
 check_strings = true
+-- expected_output_config --
+main.go:3:26: "Mistooken" is misspelled in string
+main.go:3:36: "tæxt" is misspelled in string

--- a/testdata/config.txt
+++ b/testdata/config.txt
@@ -1,12 +1,12 @@
 # Show config can be used and turned off.
 ! gospel -show=false
-stdout 'main.go:3:25: "Mistooken" is misspelled in string'
-stdout 'main.go:3:25: "tæxt" is misspelled in string'
+stdout 'main.go:3:26: "Mistooken" is misspelled in string'
+stdout 'main.go:3:36: "tæxt" is misspelled in string'
 ! stderr .
 
 ! gospel -show=false -config=true
-stdout 'main.go:3:25: "Mistooken" is misspelled in string'
-stdout 'main.go:3:25: "tæxt" is misspelled in string'
+stdout 'main.go:3:26: "Mistooken" is misspelled in string'
+stdout 'main.go:3:36: "tæxt" is misspelled in string'
 ! stderr .
 
 gospel -show=false -config=false

--- a/testdata/dep_type_word.txt
+++ b/testdata/dep_type_word.txt
@@ -4,8 +4,8 @@ gospel -ignore-idents=true
 ! stderr .
 
 ! gospel -ignore-idents=false
-stdout 'main.go:5:1: "Foooooo" is misspelled in comment'
-stdout 'main.go:5:1: "Baaaaaa" is misspelled in comment'
+stdout 'main.go:5:6: "Foooooo" is misspelled in comment'
+stdout 'main.go:5:18: "Baaaaaa" is misspelled in comment'
 ! stderr .
 
 -- go.mod --

--- a/testdata/dep_type_word.txt
+++ b/testdata/dep_type_word.txt
@@ -1,12 +1,12 @@
 # Show dependency identifiers can mask misspelling.
+
 gospel -ignore-idents=true
 ! stdout .
 ! stderr .
 
 ! gospel -ignore-idents=false
-stdout 'main.go:5:6: "Foooooo" is misspelled in comment'
-stdout 'main.go:5:18: "Baaaaaa" is misspelled in comment'
 ! stderr .
+cmp stdout expected_output
 
 -- go.mod --
 module dummy
@@ -33,3 +33,7 @@ func Bar() {}
 package q
 
 func Baaaaaa() {}
+-- expected_output --
+main.go:5:6: "Foooooo" is misspelled in comment
+main.go:5:18: "Baaaaaa" is misspelled in comment
+	// p.[31;1;3mFoooooo[0m and [31;1;3mBaaaaaa[0m

--- a/testdata/directive_words.txt
+++ b/testdata/directive_words.txt
@@ -1,12 +1,14 @@
 # Ignore words in directive comments.
 ! gospel -show=false -ignore-idents=false
-stdout 'main.go:5:1: "gennerated" is misspelled in comment'
-stdout 'main.go:5:1: "sumtype" is misspelled in comment'
-stdout 'main.go:5:1: "ignoretypes" is misspelled in comment'
+stdout 'main.go:3:55: "gennerated" is misspelled in comment'
+stdout 'main.go:5:12: "gennerated" is misspelled in comment'
+stdout 'main.go:6:6: "sumtype" is misspelled in comment'
+stdout 'main.go:6:14: "ignoretypes" is misspelled in comment'
 ! stderr .
 
 ! gospel -show=false -misspellings=words
-stdout 'main.go:5:1: "gennerated" is misspelled in comment'
+stdout 'main.go:3:55: "gennerated" is misspelled in comment'
+stdout 'main.go:5:12: "gennerated" is misspelled in comment'
 ! stderr .
 
 cmp words expected_words

--- a/testdata/directive_words.txt
+++ b/testdata/directive_words.txt
@@ -1,15 +1,12 @@
 # Ignore words in directive comments.
+
 ! gospel -show=false -ignore-idents=false
-stdout 'main.go:3:55: "gennerated" is misspelled in comment'
-stdout 'main.go:5:12: "gennerated" is misspelled in comment'
-stdout 'main.go:6:6: "sumtype" is misspelled in comment'
-stdout 'main.go:6:14: "ignoretypes" is misspelled in comment'
 ! stderr .
+cmp stdout expected_output_noignore
 
 ! gospel -show=false -misspellings=words
-stdout 'main.go:3:55: "gennerated" is misspelled in comment'
-stdout 'main.go:5:12: "gennerated" is misspelled in comment'
 ! stderr .
+cmp stdout expected_output_ignore
 
 cmp words expected_words
 
@@ -27,3 +24,11 @@ func main() {
 -- expected_words --
 1
 gennerated
+-- expected_output_noignore --
+main.go:3:55: "gennerated" is misspelled in comment
+main.go:5:12: "gennerated" is misspelled in comment
+main.go:6:6: "sumtype" is misspelled in comment
+main.go:6:14: "ignoretypes" is misspelled in comment
+-- expected_output_ignore --
+main.go:3:55: "gennerated" is misspelled in comment
+main.go:5:12: "gennerated" is misspelled in comment

--- a/testdata/help.txt
+++ b/testdata/help.txt
@@ -1,4 +1,5 @@
 # Show successful help.
+
 gospel -h
 stderr 'usage: gospel \[options\] \[packages\]'
 ! stdout .

--- a/testdata/indents.txt
+++ b/testdata/indents.txt
@@ -1,7 +1,7 @@
 # Show correct indent behaviour.
 
 ! gospel -check-strings
-
+! stderr .
 cmp stdout expected
 
 -- go.mod --

--- a/testdata/indents.txt
+++ b/testdata/indents.txt
@@ -1,0 +1,156 @@
+# Show correct indent behaviour.
+
+! gospel -check-strings
+
+cmp stdout expected
+
+-- go.mod --
+module dummy
+-- main.go --
+package main
+
+/* previous block
+*/
+// Preffix
+/*
+Zero level non-indented blockcomment.
+Second line.
+*/
+// Sufffix
+/* subsequent block
+*/
+
+// Prefix
+/*
+	Zero level indented blockcomment.
+	Second line.
+*/
+// Sufffix
+
+// Zero level linecomment.
+
+const c0d = "Zero level doublequoted."
+
+const c0s = `
+Zero level singlequoted.
+Second line.
+`
+
+func main() {
+	/* previous block
+	*/
+	// Preffix
+	/*
+		First level indented blockcomment.
+		Second line.
+	*/
+	// Sufffix
+	/* subsequent block
+	*/
+
+	// First level linecomment.
+
+	const c1d = "First level doublequoted."
+
+	const c1s = `
+First level singlequoted.
+Second line.
+`
+
+	{
+		/* previous block
+		*/
+		// Preffix
+		/*
+			Second level indented blockcomment.
+			Second line.
+		*/
+		// Sufffix
+		/* subsequent block
+		*/
+
+		// Second level linecomment.
+
+		const c1d = "Second level doublequoted."
+
+		const c1s = `
+Second level singlequoted.
+Second line.
+`
+	}
+}
+-- expected --
+main.go:5:4: "Preffix" is misspelled in comment
+main.go:6:28: "blockcomment" is misspelled in comment
+main.go:10:4: "Sufffix" is misspelled in comment
+	/* previous block
+	*/
+	// [31;1;3mPreffix[0m
+	/*
+	Zero level non-indented [31;1;3mblockcomment[0m.
+	Second line.
+	*/
+	// [31;1;3mSufffix[0m
+	/* subsequent block
+	*/
+main.go:15:25: "blockcomment" is misspelled in comment
+main.go:19:4: "Sufffix" is misspelled in comment
+	// Prefix
+	/*
+		Zero level indented [31;1;3mblockcomment[0m.
+		Second line.
+	*/
+	// [31;1;3mSufffix[0m
+main.go:21:15: "linecomment" is misspelled in comment
+	// Zero level [31;1;3mlinecomment[0m.
+main.go:23:25: "doublequoted" is misspelled in string
+	"Zero level [31;1;3mdoublequoted[0m."
+main.go:25:26: "singlequoted" is misspelled in string
+	`
+	Zero level [31;1;3msinglequoted[0m.
+	Second line.
+	`
+main.go:33:5: "Preffix" is misspelled in comment
+main.go:34:28: "blockcomment" is misspelled in comment
+main.go:38:5: "Sufffix" is misspelled in comment
+	/* previous block
+	*/
+	// [31;1;3mPreffix[0m
+	/*
+		First level indented [31;1;3mblockcomment[0m.
+		Second line.
+	*/
+	// [31;1;3mSufffix[0m
+	/* subsequent block
+	*/
+main.go:42:17: "linecomment" is misspelled in comment
+	// First level [31;1;3mlinecomment[0m.
+main.go:44:27: "doublequoted" is misspelled in string
+	"First level [31;1;3mdoublequoted[0m."
+main.go:46:28: "singlequoted" is misspelled in string
+	`
+	First level [31;1;3msinglequoted[0m.
+	Second line.
+	`
+main.go:54:6: "Preffix" is misspelled in comment
+main.go:55:31: "blockcomment" is misspelled in comment
+main.go:59:6: "Sufffix" is misspelled in comment
+	/* previous block
+	*/
+	// [31;1;3mPreffix[0m
+	/*
+		Second level indented [31;1;3mblockcomment[0m.
+		Second line.
+	*/
+	// [31;1;3mSufffix[0m
+	/* subsequent block
+	*/
+main.go:63:19: "linecomment" is misspelled in comment
+	// Second level [31;1;3mlinecomment[0m.
+main.go:65:29: "doublequoted" is misspelled in string
+	"Second level [31;1;3mdoublequoted[0m."
+main.go:67:30: "singlequoted" is misspelled in string
+	`
+	Second level [31;1;3msinglequoted[0m.
+	Second line.
+	`

--- a/testdata/label.txt
+++ b/testdata/label.txt
@@ -1,4 +1,5 @@
 # Show labels are added to dictionary; no change in functionality.
+
 gospel
 ! stdout .
 ! stderr .

--- a/testdata/local_dictionary.txt
+++ b/testdata/local_dictionary.txt
@@ -1,8 +1,8 @@
 # Generate a local dictionary of misspelled words.
+
 ! gospel -show=false -misspellings=.words -update-dict=false
-stdout 'main.go:3:4: "Speeling" is misspelled in comment'
-! stdout '	// \x1b\[31;1;3mSpeeling\x1b\[0m\ error.'
 ! stderr .
+cmp stdout expected_output
 
 # Check it matches our expectation.
 cmp .words expected_words
@@ -23,3 +23,5 @@ func main() {
 -- expected_words --
 1
 Speeling
+-- expected_output --
+main.go:3:4: "Speeling" is misspelled in comment

--- a/testdata/local_dictionary.txt
+++ b/testdata/local_dictionary.txt
@@ -1,7 +1,7 @@
 # Generate a local dictionary of misspelled words.
 ! gospel -show=false -misspellings=.words -update-dict=false
-stdout 'main.go:3:1: "Speeling" is misspelled in comment'
-! stdout '	\x1b\[31;1;3mSpeeling\x1b\[0m\ error.'
+stdout 'main.go:3:4: "Speeling" is misspelled in comment'
+! stdout '	// \x1b\[31;1;3mSpeeling\x1b\[0m\ error.'
 ! stderr .
 
 # Check it matches our expectation.

--- a/testdata/misspelling_comment.txt
+++ b/testdata/misspelling_comment.txt
@@ -1,8 +1,8 @@
 # Show misspelling in a comment and correct colourisation.
+
 ! gospel
-stdout 'main.go:3:4: "Speeling" is misspelled in comment'
-stdout '	// \x1b\[31;1;3mSpeeling\x1b\[0m\ error.'
 ! stderr .
+cmp stdout expected_output
 
 -- go.mod --
 module dummy
@@ -12,3 +12,6 @@ package main
 // Speeling error.
 func main() {
 }
+-- expected_output --
+main.go:3:4: "Speeling" is misspelled in comment
+	// [31;1;3mSpeeling[0m error.

--- a/testdata/misspelling_comment.txt
+++ b/testdata/misspelling_comment.txt
@@ -1,7 +1,7 @@
 # Show misspelling in a comment and correct colourisation.
 ! gospel
-stdout 'main.go:3:1: "Speeling" is misspelled in comment'
-stdout '	\x1b\[31;1;3mSpeeling\x1b\[0m\ error.'
+stdout 'main.go:3:4: "Speeling" is misspelled in comment'
+stdout '	// \x1b\[31;1;3mSpeeling\x1b\[0m\ error.'
 ! stderr .
 
 -- go.mod --

--- a/testdata/misspelling_string.txt
+++ b/testdata/misspelling_string.txt
@@ -8,7 +8,7 @@ gospel -check-strings=false
 ! stderr .
 
 ! gospel -check-strings
-stdout 'main.go:4:10: "Speeling" is misspelled in string'
+stdout 'main.go:4:11: "Speeling" is misspelled in string'
 stdout '	"\x1b\[31;1;3mSpeeling\x1b\[0m error\."'
 ! stderr .
 

--- a/testdata/misspelling_string.txt
+++ b/testdata/misspelling_string.txt
@@ -1,4 +1,5 @@
 # Show misspelling in a comment and correct colourisation only when asked.
+
 gospel
 ! stdout .
 ! stderr .
@@ -8,9 +9,8 @@ gospel -check-strings=false
 ! stderr .
 
 ! gospel -check-strings
-stdout 'main.go:4:11: "Speeling" is misspelled in string'
-stdout '	"\x1b\[31;1;3mSpeeling\x1b\[0m error\."'
 ! stderr .
+cmp stdout expected_output
 
 -- go.mod --
 module dummy
@@ -20,3 +20,6 @@ package main
 func main() {
 	println("Speeling error.")
 }
+-- expected_output --
+main.go:4:11: "Speeling" is misspelled in string
+	"[31;1;3mSpeeling[0m error."

--- a/testdata/no_find_lang.txt
+++ b/testdata/no_find_lang.txt
@@ -1,4 +1,5 @@
 # Report correct error when there is no dictionary for the requested language.
+
 ! gospel -lang='en_FR'
 ! stdout .
 stderr 'no en_FR dictionary found in:'

--- a/testdata/no_lang.txt
+++ b/testdata/no_lang.txt
@@ -1,4 +1,5 @@
 # Report the correct error when no language is requested.
+
 ! gospel -lang=''
 ! stdout .
 stderr 'missing lang flag'

--- a/testdata/numbers.txt
+++ b/testdata/numbers.txt
@@ -1,15 +1,8 @@
 # Show numbers are ignored when requested.
 
 ! gospel -ignore-numbers=false -show=false
-stdout 'main.go:10:7: "1e43" is misspelled in comment'
-stdout 'main.go:10:17: "0xE596B7B0_C643C719" is misspelled in comment'
-stdout 'main.go:11:15: "0xE596B7B0_C643C719_6D9CCD05_D0000000" is misspelled in comment'
-stdout 'main.go:19:47: "1e-348" is misspelled in comment'
-stdout 'main.go:20:47: "1e-347" is misspelled in comment'
-stdout 'main.go:21:47: "1e-346" is misspelled in comment'
-stdout 'main.go:22:47: "1e-345" is misspelled in comment'
-stdout 'main.go:23:47: "1e-344" is misspelled in comment'
 ! stderr .
+cmp stdout expected_output
 
 gospel -ignore-numbers=true
 ! stdout .
@@ -46,3 +39,13 @@ var detailedPowersOfTen = [...][2]uint64{
 2
 mpb
 wuffs
+-- expected_output --
+main.go:10:7: "1e43" is misspelled in comment
+main.go:10:17: "0xE596B7B0_C643C719" is misspelled in comment
+main.go:11:7: "1e43" is misspelled in comment
+main.go:11:15: "0xE596B7B0_C643C719_6D9CCD05_D0000000" is misspelled in comment
+main.go:19:47: "1e-348" is misspelled in comment
+main.go:20:47: "1e-347" is misspelled in comment
+main.go:21:47: "1e-346" is misspelled in comment
+main.go:22:47: "1e-345" is misspelled in comment
+main.go:23:47: "1e-344" is misspelled in comment

--- a/testdata/numbers.txt
+++ b/testdata/numbers.txt
@@ -1,14 +1,14 @@
 # Show numbers are ignored when requested.
 
 ! gospel -ignore-numbers=false -show=false
-stdout 'main.go:7:1: "1e43" is misspelled in comment'
-stdout 'main.go:7:1: "0xE596B7B0_C643C719" is misspelled in comment'
-stdout 'main.go:7:1: "0xE596B7B0_C643C719_6D9CCD05_D0000000" is misspelled in comment'
-stdout 'main.go:19:44: "1e-348" is misspelled in comment'
-stdout 'main.go:20:44: "1e-347" is misspelled in comment'
-stdout 'main.go:21:44: "1e-346" is misspelled in comment'
-stdout 'main.go:22:44: "1e-345" is misspelled in comment'
-stdout 'main.go:23:44: "1e-344" is misspelled in comment'
+stdout 'main.go:10:7: "1e43" is misspelled in comment'
+stdout 'main.go:10:17: "0xE596B7B0_C643C719" is misspelled in comment'
+stdout 'main.go:11:15: "0xE596B7B0_C643C719_6D9CCD05_D0000000" is misspelled in comment'
+stdout 'main.go:19:47: "1e-348" is misspelled in comment'
+stdout 'main.go:20:47: "1e-347" is misspelled in comment'
+stdout 'main.go:21:47: "1e-346" is misspelled in comment'
+stdout 'main.go:22:47: "1e-345" is misspelled in comment'
+stdout 'main.go:23:47: "1e-344" is misspelled in comment'
 ! stderr .
 
 gospel -ignore-numbers=true

--- a/testdata/patterns.txt
+++ b/testdata/patterns.txt
@@ -1,7 +1,7 @@
 # Show regexp can ignore misspelled words.
 ! gospel -show=false -config=false
-stdout 'main.go:3:1: "Speeling" is misspelled in comment'
-stdout 'main.go:3:1: "mistaek" is misspelled in comment'
+stdout 'main.go:3:4: "Speeling" is misspelled in comment'
+stdout 'main.go:3:13: "mistaek" is misspelled in comment'
 ! stderr .
 
 gospel -show=false

--- a/testdata/patterns.txt
+++ b/testdata/patterns.txt
@@ -1,8 +1,8 @@
 # Show regexp can ignore misspelled words.
+
 ! gospel -show=false -config=false
-stdout 'main.go:3:4: "Speeling" is misspelled in comment'
-stdout 'main.go:3:13: "mistaek" is misspelled in comment'
 ! stderr .
+cmp stdout expected_output
 
 gospel -show=false
 ! stdout .
@@ -18,3 +18,6 @@ func main() {
 }
 -- .gospel.conf --
 patterns = ["^S.e{2}.{4}$", "sta"]
+-- expected_output --
+main.go:3:4: "Speeling" is misspelled in comment
+main.go:3:13: "mistaek" is misspelled in comment

--- a/testdata/plural_types.txt
+++ b/testdata/plural_types.txt
@@ -1,9 +1,8 @@
 # Show types are recognised in their plural.
 
 ! gospel -show=false
-! stdout '"privatetypes" is misspelled in comment'
-stdout 'main.go:7:26: "privatevalues" is misspelled in comment'
 ! stderr .
+cmp stdout expected_output
 
 -- go.mod --
 module dummy
@@ -20,3 +19,5 @@ func main() {
 	var privatevalue privatetype
 	println(privatevalue)
 }
+-- expected_output --
+main.go:7:26: "privatevalues" is misspelled in comment

--- a/testdata/plural_types.txt
+++ b/testdata/plural_types.txt
@@ -1,8 +1,8 @@
 # Show types are recognised in their plural.
 
 ! gospel -show=false
-! stdout 'main.go:3:1: "privatetypes" is misspelled in comment'
-stdout 'main.go:7:2: "privatevalues" is misspelled in comment'
+! stdout '"privatetypes" is misspelled in comment'
+stdout 'main.go:7:26: "privatevalues" is misspelled in comment'
 ! stderr .
 
 -- go.mod --

--- a/testdata/rune_literal.txt
+++ b/testdata/rune_literal.txt
@@ -1,4 +1,5 @@
 gospel -show=false -check-strings -max-word-len=20 -entropy-filter
+
 ! stdout .
 ! stderr .
 

--- a/testdata/single.txt
+++ b/testdata/single.txt
@@ -1,8 +1,8 @@
 # Show single-letter misspelling is ignored when requested.
+
 ! gospel -ignore-single=false
-stdout 'main.go:3:4: "ϵ" is misspelled in comment'
-stdout '	// \x1b\[31;1;3mϵ\x1b\[0m'
 ! stderr .
+cmp stdout expected_output
 
 gospel -ignore-single=true
 ! stdout .
@@ -16,3 +16,6 @@ package main
 // ϵ
 func main() {
 }
+-- expected_output --
+main.go:3:4: "ϵ" is misspelled in comment
+	// [31;1;3mϵ[0m

--- a/testdata/single.txt
+++ b/testdata/single.txt
@@ -1,7 +1,7 @@
 # Show single-letter misspelling is ignored when requested.
 ! gospel -ignore-single=false
-stdout 'main.go:3:1: "ϵ" is misspelled in comment'
-stdout '	\x1b\[31;1;3mϵ\x1b\[0m'
+stdout 'main.go:3:4: "ϵ" is misspelled in comment'
+stdout '	// \x1b\[31;1;3mϵ\x1b\[0m'
 ! stderr .
 
 gospel -ignore-single=true

--- a/testdata/struct_tag.txt
+++ b/testdata/struct_tag.txt
@@ -4,9 +4,9 @@
 ! stdout '"maskedmistake"'
 ! stdout '"emb"'
 ! stdout '"edded"'
-stdout 'main.go:3:1: "badtag" is misspelled in comment'
-stdout 'main.go:3:1: "unmaskedmistake" is misspelled in comment'
-stdout 'main.go:3:1: "failedmistake" is misspelled in comment'
+stdout 'main.go:5:4: "badtag" is misspelled in comment'
+stdout 'main.go:6:4: "unmaskedmistake" is misspelled in comment'
+stdout 'main.go:8:4: "failedmistake" is misspelled in comment'
 ! stderr .
 
 -- go.mod --

--- a/testdata/struct_tag.txt
+++ b/testdata/struct_tag.txt
@@ -1,13 +1,8 @@
 # Words are ignored when included in valid struct tags.
+
 ! gospel -show=false
-! stdout '"goodtag"'
-! stdout '"maskedmistake"'
-! stdout '"emb"'
-! stdout '"edded"'
-stdout 'main.go:5:4: "badtag" is misspelled in comment'
-stdout 'main.go:6:4: "unmaskedmistake" is misspelled in comment'
-stdout 'main.go:8:4: "failedmistake" is misspelled in comment'
 ! stderr .
+cmp stdout expected_output
 
 -- go.mod --
 module dummy
@@ -33,3 +28,7 @@ type E int
 
 func main() {
 }
+-- expected_output --
+main.go:5:4: "badtag" is misspelled in comment
+main.go:6:4: "unmaskedmistake" is misspelled in comment
+main.go:8:4: "failedmistake" is misspelled in comment

--- a/testdata/suggestions.txt
+++ b/testdata/suggestions.txt
@@ -4,42 +4,34 @@
 
 # never show suggestions
 ! gospel -show=false -suggest=0
-stdout 'main.go:6:4: "coloured" is misspelled in comment$'
-stdout 'main.go:10:4: "coloured" is misspelled in comment$'
-stdout 'main.go:10:13: "coloured" is misspelled in comment$'
 ! stderr .
+cmp stdout expected_noshow_nosuggest
+
 
 # show suggestion for first occurrence 
 ! gospel -show=false -suggest=1
-stdout 'main.go:6:4: "coloured" is misspelled in comment \(suggest: colored, co loured, co-loured\)'
-stdout 'main.go:10:4: "coloured" is misspelled in comment$'
-stdout 'main.go:10:13: "coloured" is misspelled in comment$'
 ! stderr .
+cmp stdout expected_noshow_suggest_one
+
 
 # always show suggestions
 ! gospel -show=false -suggest=2
-stdout 'main.go:6:4: "coloured" is misspelled in comment \(suggest: colored, co loured, co-loured\)$'
-stdout 'main.go:10:4: "coloured" is misspelled in comment \(suggest: colored, co loured, co-loured\)$'
-stdout 'main.go:10:13: "coloured" is misspelled in comment \(suggest: colored, co loured, co-loured\)$'
 ! stderr .
+cmp stdout expected_noshow_suggest_always
 
 
 # Coloured when -show=true
 
 # show suggestion for first occurrence 
 ! gospel -suggest=1
-stdout 'main.go:6:4: "coloured" is misspelled in comment \(suggest: \x1b\[32;1;3mcolored\x1b\[0m,'
-stdout 'main.go:10:4: "coloured" is misspelled in comment$'
-stdout 'main.go:10:13: "coloured" is misspelled in comment$'
 ! stderr .
+cmp stdout expected_show_suggest_one
+
 
 # always show suggestions
 ! gospel -suggest=2
-stdout 'main.go:6:4: "coloured" is misspelled in comment \(suggest: \x1b\[32;1;3mcolored\x1b\[0m,'
-stdout 'main.go:10:4: "coloured" is misspelled in comment \(suggest: \x1b\[32;1;3mcolored\x1b\[0m,'
-stdout 'main.go:10:13: "coloured" is misspelled in comment \(suggest: \x1b\[32;1;3mcolored\x1b\[0m,'
 ! stderr .
-
+cmp stdout expected_show_suggest_always
 
 -- go.mod --
 module dummy
@@ -56,3 +48,27 @@ func fn1() {
 // coloured coloured
 func fn2() {
 }
+-- expected_noshow_nosuggest --
+main.go:6:4: "coloured" is misspelled in comment
+main.go:10:4: "coloured" is misspelled in comment
+main.go:10:13: "coloured" is misspelled in comment
+-- expected_noshow_suggest_one --
+main.go:6:4: "coloured" is misspelled in comment (suggest: colored, co loured, co-loured)
+main.go:10:4: "coloured" is misspelled in comment
+main.go:10:13: "coloured" is misspelled in comment
+-- expected_noshow_suggest_always --
+main.go:6:4: "coloured" is misspelled in comment (suggest: colored, co loured, co-loured)
+main.go:10:4: "coloured" is misspelled in comment (suggest: colored, co loured, co-loured)
+main.go:10:13: "coloured" is misspelled in comment (suggest: colored, co loured, co-loured)
+-- expected_show_suggest_one --
+main.go:6:4: "coloured" is misspelled in comment (suggest: [32;1;3mcolored[0m, [32;1;3mco loured[0m, [32;1;3mco-loured[0m)
+	// [31;1;3mcoloured[0m
+main.go:10:4: "coloured" is misspelled in comment
+main.go:10:13: "coloured" is misspelled in comment
+	// [31;1;3mcoloured[0m [31;1;3mcoloured[0m
+-- expected_show_suggest_always --
+main.go:6:4: "coloured" is misspelled in comment (suggest: [32;1;3mcolored[0m, [32;1;3mco loured[0m, [32;1;3mco-loured[0m)
+	// [31;1;3mcoloured[0m
+main.go:10:4: "coloured" is misspelled in comment (suggest: [32;1;3mcolored[0m, [32;1;3mco loured[0m, [32;1;3mco-loured[0m)
+main.go:10:13: "coloured" is misspelled in comment (suggest: [32;1;3mcolored[0m, [32;1;3mco loured[0m, [32;1;3mco-loured[0m)
+	// [31;1;3mcoloured[0m [31;1;3mcoloured[0m

--- a/testdata/suggestions.txt
+++ b/testdata/suggestions.txt
@@ -4,20 +4,23 @@
 
 # never show suggestions
 ! gospel -show=false -suggest=0
-stdout 'main.go:6:1: "coloured" is misspelled in comment$'
-stdout 'main.go:10:1: "coloured" is misspelled in comment$'
+stdout 'main.go:6:4: "coloured" is misspelled in comment$'
+stdout 'main.go:10:4: "coloured" is misspelled in comment$'
+stdout 'main.go:10:13: "coloured" is misspelled in comment$'
 ! stderr .
 
 # show suggestion for first occurrence 
 ! gospel -show=false -suggest=1
-stdout 'main.go:6:1: "coloured" is misspelled in comment \(suggest: colored, co loured, co-loured\)'
-stdout 'main.go:10:1: "coloured" is misspelled in comment$'
+stdout 'main.go:6:4: "coloured" is misspelled in comment \(suggest: colored, co loured, co-loured\)'
+stdout 'main.go:10:4: "coloured" is misspelled in comment$'
+stdout 'main.go:10:13: "coloured" is misspelled in comment$'
 ! stderr .
 
 # always show suggestions
 ! gospel -show=false -suggest=2
-stdout 'main.go:6:1: "coloured" is misspelled in comment \(suggest: colored, co loured, co-loured\)$'
-stdout 'main.go:10:1: "coloured" is misspelled in comment \(suggest: colored, co loured, co-loured\)$'
+stdout 'main.go:6:4: "coloured" is misspelled in comment \(suggest: colored, co loured, co-loured\)$'
+stdout 'main.go:10:4: "coloured" is misspelled in comment \(suggest: colored, co loured, co-loured\)$'
+stdout 'main.go:10:13: "coloured" is misspelled in comment \(suggest: colored, co loured, co-loured\)$'
 ! stderr .
 
 
@@ -25,14 +28,16 @@ stdout 'main.go:10:1: "coloured" is misspelled in comment \(suggest: colored, co
 
 # show suggestion for first occurrence 
 ! gospel -suggest=1
-stdout 'main.go:6:1: "coloured" is misspelled in comment \(suggest: \x1b\[32;1;3mcolored\x1b\[0m,'
-stdout 'main.go:10:1: "coloured" is misspelled in comment$'
+stdout 'main.go:6:4: "coloured" is misspelled in comment \(suggest: \x1b\[32;1;3mcolored\x1b\[0m,'
+stdout 'main.go:10:4: "coloured" is misspelled in comment$'
+stdout 'main.go:10:13: "coloured" is misspelled in comment$'
 ! stderr .
 
 # always show suggestions
 ! gospel -suggest=2
-stdout 'main.go:6:1: "coloured" is misspelled in comment \(suggest: \x1b\[32;1;3mcolored\x1b\[0m,'
-stdout 'main.go:10:1: "coloured" is misspelled in comment \(suggest: \x1b\[32;1;3mcolored\x1b\[0m,'
+stdout 'main.go:6:4: "coloured" is misspelled in comment \(suggest: \x1b\[32;1;3mcolored\x1b\[0m,'
+stdout 'main.go:10:4: "coloured" is misspelled in comment \(suggest: \x1b\[32;1;3mcolored\x1b\[0m,'
+stdout 'main.go:10:13: "coloured" is misspelled in comment \(suggest: \x1b\[32;1;3mcolored\x1b\[0m,'
 ! stderr .
 
 
@@ -48,6 +53,6 @@ func main() {
 func fn1() {
 }
 
-// coloured
+// coloured coloured
 func fn2() {
 }

--- a/testdata/type_word.txt
+++ b/testdata/type_word.txt
@@ -4,8 +4,8 @@ gospel -ignore-idents=true
 ! stderr .
 
 ! gospel -ignore-idents=false
-stdout 'main.go:3:1: "_Speeling_" is misspelled in comment'
-stdout '	\x1b\[31;1;3m_Speeling_\x1b\[0m\ error.'
+stdout 'main.go:3:4: "_Speeling_" is misspelled in comment'
+stdout '	// \x1b\[31;1;3m_Speeling_\x1b\[0m\ error.'
 
 -- go.mod --
 module dummy

--- a/testdata/type_word.txt
+++ b/testdata/type_word.txt
@@ -1,11 +1,12 @@
 # Show identifiers can mask misspelling and flanking underscores don't prevent match.
+
 gospel -ignore-idents=true
 ! stdout .
 ! stderr .
 
 ! gospel -ignore-idents=false
-stdout 'main.go:3:4: "_Speeling_" is misspelled in comment'
-stdout '	// \x1b\[31;1;3m_Speeling_\x1b\[0m\ error.'
+! stderr .
+cmp stdout expected_output
 
 -- go.mod --
 module dummy
@@ -16,3 +17,6 @@ package main
 func main() {
 	type Speeling int
 }
+-- expected_output --
+main.go:3:4: "_Speeling_" is misspelled in comment
+	// [31;1;3m_Speeling_[0m error.

--- a/testdata/underscore_fragments.txt
+++ b/testdata/underscore_fragments.txt
@@ -1,7 +1,7 @@
 # Show underscore-separated words are allowed when all parts are accepted as correct.
 ! gospel -ignore-single=false -max-word-len=0
-stdout 'main.go:3:1: "_ϵ_together_unknown_apart_correct_when_singles_allowed_" is misspelled in comment'
-stdout '	\x1b\[31;1;3m_ϵ_together_unknown_apart_correct_when_singles_allowed_\x1b\[0m'
+stdout 'main.go:3:4: "_ϵ_together_unknown_apart_correct_when_singles_allowed_" is misspelled in comment'
+stdout '	// \x1b\[31;1;3m_ϵ_together_unknown_apart_correct_when_singles_allowed_\x1b\[0m'
 ! stderr .
 
 gospel -ignore-single=false -max-word-len=30

--- a/testdata/underscore_fragments.txt
+++ b/testdata/underscore_fragments.txt
@@ -1,8 +1,8 @@
 # Show underscore-separated words are allowed when all parts are accepted as correct.
+
 ! gospel -ignore-single=false -max-word-len=0
-stdout 'main.go:3:4: "_ϵ_together_unknown_apart_correct_when_singles_allowed_" is misspelled in comment'
-stdout '	// \x1b\[31;1;3m_ϵ_together_unknown_apart_correct_when_singles_allowed_\x1b\[0m'
 ! stderr .
+cmp stdout expected_output
 
 gospel -ignore-single=false -max-word-len=30
 ! stdout .
@@ -20,3 +20,6 @@ package main
 // _ϵ_together_unknown_apart_correct_when_singles_allowed_
 func main() {
 }
+-- expected_output --
+main.go:3:4: "_ϵ_together_unknown_apart_correct_when_singles_allowed_" is misspelled in comment
+	// [31;1;3m_ϵ_together_unknown_apart_correct_when_singles_allowed_[0m

--- a/testdata/update_local_dictionary.txt
+++ b/testdata/update_local_dictionary.txt
@@ -1,6 +1,6 @@
 # Update an existing local dictionary of misspelled words.
 ! gospel -show=false -misspellings=.words -update-dict=true
-stdout 'main.go:3:1: "errah" is misspelled in comment'
+stdout 'main.go:3:13: "errah" is misspelled in comment'
 ! stdout 'Speeling'
 ! stderr .
 

--- a/testdata/update_local_dictionary.txt
+++ b/testdata/update_local_dictionary.txt
@@ -1,8 +1,8 @@
 # Update an existing local dictionary of misspelled words.
+
 ! gospel -show=false -misspellings=.words -update-dict=true
-stdout 'main.go:3:13: "errah" is misspelled in comment'
-! stdout 'Speeling'
 ! stderr .
+cmp stdout expected_output
 
 # Check it matches our expectation.
 cmp .words expected_words
@@ -29,3 +29,5 @@ Speeling/S
 2
 Speeling/S
 errah
+-- expected_output --
+main.go:3:13: "errah" is misspelled in comment

--- a/testdata/uppercase.txt
+++ b/testdata/uppercase.txt
@@ -1,8 +1,8 @@
 # Show all-uppercase words (including numerals and underscores) can be ignored.
+
 ! gospel -ignore-upper=false
-stdout 'main.go:3:4: "FL1M_FLAM" is misspelled in comment'
-stdout '	// \x1b\[31;1;3mFL1M_FLAM\x1b\[0m'
 ! stderr .
+cmp stdout expected_output
 
 gospel -ignore-upper=true
 ! stdout .
@@ -16,3 +16,6 @@ package main
 // FL1M_FLAM
 func main() {
 }
+-- expected_output --
+main.go:3:4: "FL1M_FLAM" is misspelled in comment
+	// [31;1;3mFL1M_FLAM[0m

--- a/testdata/uppercase.txt
+++ b/testdata/uppercase.txt
@@ -1,7 +1,7 @@
 # Show all-uppercase words (including numerals and underscores) can be ignored.
 ! gospel -ignore-upper=false
-stdout 'main.go:3:1: "FL1M_FLAM" is misspelled in comment'
-stdout '	\x1b\[31;1;3mFL1M_FLAM\x1b\[0m'
+stdout 'main.go:3:4: "FL1M_FLAM" is misspelled in comment'
+stdout '	// \x1b\[31;1;3mFL1M_FLAM\x1b\[0m'
 ! stderr .
 
 gospel -ignore-upper=true

--- a/testdata/url.txt
+++ b/testdata/url.txt
@@ -1,7 +1,7 @@
 # Show URLs can be ignored.
 
 ! gospel -show=false -mask-urls=false
-stdout 'dummy.go:3:1: "go15heapdump" is misspelled in comment'
+stdout 'dummy.go:4:25: "go15heapdump" is misspelled in comment'
 ! stderr .
 
 gospel -show=false -mask-urls=true

--- a/testdata/url.txt
+++ b/testdata/url.txt
@@ -1,8 +1,8 @@
 # Show URLs can be ignored.
 
 ! gospel -show=false -mask-urls=false
-stdout 'dummy.go:4:25: "go15heapdump" is misspelled in comment'
 ! stderr .
+cmp stdout expected_output_unmasked
 
 gospel -show=false -mask-urls=true
 ! stdout .
@@ -15,3 +15,5 @@ package dummy
 
 // The format of the dumped file is described at
 // https://golang.org/s/go15heapdump.
+-- expected_output_unmasked --
+dummy.go:4:25: "go15heapdump" is misspelled in comment

--- a/testdata/write_config.txt
+++ b/testdata/write_config.txt
@@ -1,6 +1,6 @@
 # Show config can be written.
-gospel -write-config -max-word-len=30
 
+gospel -write-config -max-word-len=30
 cmp stdout gospel.conf
 
 -- go.mod --

--- a/testdata/wrong_case.txt
+++ b/testdata/wrong_case.txt
@@ -1,7 +1,8 @@
 # Check case matters in camel-cased words.
+
 ! gospel -show=false -misspellings=words
-stdout 'main.go:5:4: "KillTimeout" is misspelled in comment'
 ! stderr .
+cmp stdout expected_output
 
 # Check the complete list matches our expectation.
 cmp words expected_words
@@ -19,3 +20,5 @@ func DefaultExecHandler(killTimeout time.Duration) {
 -- expected_words --
 1
 KillTimeout
+-- expected_output --
+main.go:5:4: "KillTimeout" is misspelled in comment

--- a/testdata/wrong_case.txt
+++ b/testdata/wrong_case.txt
@@ -1,6 +1,6 @@
 # Check case matters in camel-cased words.
 ! gospel -show=false -misspellings=words
-stdout 'main.go:5:1: "KillTimeout" is misspelled in comment'
+stdout 'main.go:5:4: "KillTimeout" is misspelled in comment'
 ! stderr .
 
 # Check the complete list matches our expectation.


### PR DESCRIPTION
We now collate and sort errors by filename and fileset position and only render a minimal context around each error. We also now provide exact positions for errors to allow an editor to go straight to errors.

Comment groups are now processed line-by-line where possible allowing spell checking of directive comments.

@mvdan If you have time to try this out from a user perspective (no code review is necessary) that would be helpful. The behaviour should support better coordination of work with an editor and reduce the amount of screen needed to be waded through.