### PR TITLE
add a reason note for case mismatch misspellings

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -10,7 +10,7 @@ jobs:
   test:
     strategy:
       matrix:
-        go-version: [1.17.x, 1.18.x]
+        go-version: [1.17.x, 1.18.x, 1.19.x]
         os: [ubuntu-18.04]
     runs-on: ${{ matrix.os }}
 

--- a/testdata/wrong_case.txt
+++ b/testdata/wrong_case.txt
@@ -21,4 +21,4 @@ func DefaultExecHandler(killTimeout time.Duration) {
 1
 KillTimeout
 -- expected_output --
-main.go:5:4: "KillTimeout" is misspelled in comment
+main.go:5:4: "KillTimeout" is misspelled (case mismatch) in comment


### PR DESCRIPTION
This provides a hint for flagged words that may be misspellings of labels due to export status.